### PR TITLE
Define start variable with local scope in the closure

### DIFF
--- a/chap7-neo4j/friendsuggest.groovy
+++ b/chap7-neo4j/friendsuggest.groovy
@@ -9,6 +9,7 @@
 Gremlin.defineStep( 'friendsuggest',
   [Vertex, Pipe],
   {
+    def start
     _().sideEffect{start = it}.both('friends').
     except([start]).out('likes').dedup
   }


### PR DESCRIPTION
I had trouble with the step definition from friendsuggest.groovy introduced on page 236 of version P1.0 of the PDF. I, [like another reader on the forum](http://forums.pragprog.com/forums/202/topics/10738), get the following error:

```
gremlin> g.V.filter{it.name=='Patty'}.friendsuggest.name
==> No such property: start for class: groovysh_evaluate
```

I think it's related to variable scoping in the Groovy Shell, and the attached commit fixes it for me.

Here's my working:

```
gremlin> start
==> No such property: start for class: groovysh_evaluate
gremlin> Gremlin.defineStep( 'friendsuggest',
gremlin>   [Vertex, Pipe],
gremlin>   {
gremlin>     _().sideEffect{start = it}.both('friends').except(
gremlin>     [start]).out('likes').dedup
gremlin>   }
gremlin> )
==>
gremlin> g.V.filter{it.name=='Patty'}.friendsuggest.name
==> No such property: start for class: groovysh_evaluate
gremlin> start = 1
==> 1
gremlin> g.V.filter{it.name=='Patty'}.friendsuggest.name
==> Prancing Wolf Ice Wine 2007
==> Prancing Wolf Kabinett 2002
gremlin> start
==> v[8]
gremlin> start.name
==> Patty
```

This shows that we start with no shell variable name start, then define the `friendsuggest` step as in the book, and then see the error I report above. Then I define a shell variable named `start` and now the query works as expected. Notice that my shell variable has been overwritten by the execution of `friendsuggest`.

Here's the better result from using a step defined identically except with a local variable definition for the internal variable:

```
gremlin> Gremlin.defineStep( 'fwendsuggest',
gremlin>   [Vertex, Pipe],
gremlin>   {
gremlin>     def fwendstart
gremlin>     _().sideEffect{fwendstart = it}.both('friends').except(
gremlin>     [fwendstart]).out('likes').dedup
gremlin>   }
gremlin> )
==>
gremlin> fwendstart
==> No such property: fwendstart for class: groovysh_evaluate
gremlin> g.V.filter{it.name=='Patty'}.fwendsuggest.name
==> Prancing Wolf Ice Wine 2007
==> Prancing Wolf Kabinett 2002
gremlin> fwendstart
==> No such property: fwendstart for class: groovysh_evaluate
```
