### PR TITLE
Revised Redis and CouchDB Node scripts due to updated Node library APIs 

### DIFF
--- a/chap8-redis/populate_couch.js
+++ b/chap8-redis/populate_couch.js
@@ -112,7 +112,6 @@ function populateBands() {
       bandsBatch = [];
 	  
     bandKeys.forEach(function(bandKey) {
-      console.log(bandKey);
       // substring of 'band:'.length gives us the band name
       var bandName = bandKey.substring(5);
       redisClient.smembers(bandKey, function(error, artists) {

--- a/chap8-redis/populate_couch.js
+++ b/chap8-redis/populate_couch.js
@@ -19,8 +19,7 @@ var
   http = require('http'),
   redis = require('redis'),
 
-  // database clients
-  couchClient = http.createClient(5984, 'localhost'),
+  // database client
   redisClient = redis.createClient(6379);
 
 /**
@@ -62,11 +61,14 @@ function trackLineCount( increment ) {
  */
 function postDoc( url, docsString, count ) {
 
-  var request = couchClient.request(
-    'POST',
-    url,
-    { 'Content-Type' : 'application/json' });
-  request.end( docsString );
+  var request = http.request(
+    { hostname : 'localhost',
+      port: 5984,
+      path: url,
+      method: 'POST',
+      headers: {
+          'Content-Type': 'application/json'}
+    });
 
   request.on('response', function(response) {
     if(response.statusCode == 201)
@@ -75,6 +77,8 @@ function postDoc( url, docsString, count ) {
   on('error', function(e) {
     console.log('postDoc Got error: ' + e.message);
   });
+  request.write(docsString)
+  request.end(); 
 };
 
 /*
@@ -95,7 +99,11 @@ function postDoc( url, docsString, count ) {
 function populateBands() {
 
   // First, create the couch database
-  couchClient.request('PUT', couchDBpath).end();
+  http.request(
+    { hostname : 'localhost',
+      port: 5984,
+      path: couchDBpath,
+      method: 'PUT'}).end(); 
 
   redisClient.keys('band:*', function(error, bandKeys) {
     totalBands = bandKeys.length;
@@ -104,6 +112,7 @@ function populateBands() {
       bandsBatch = [];
 	  
     bandKeys.forEach(function(bandKey) {
+      console.log(bandKey);
       // substring of 'band:'.length gives us the band name
       var bandName = bandKey.substring(5);
       redisClient.smembers(bandKey, function(error, artists) {

--- a/chap8-redis/pre_populate.js
+++ b/chap8-redis/pre_populate.js
@@ -47,15 +47,16 @@ function trackLineCount() {
 function populateRedis() {
   csv().
   from.path( tsvFileName, { delimiter: '\t', quote: '' }).
-  on('data', function(data, index) {
+  on('record', function(record, index) {
     var
-      artist = data[2],
-      band = data[3],
-      roles = buildRoles(data[4]);
+      artist = record[2],
+      band = record[3],
+      roles = buildRoles(record[4]);
     if( band === '' || artist === '' ) {
       trackLineCount();
       return true;
-    }
+   }
+    //console.log('#'+index+' '+JSON.stringify(record));
     redis_client.sadd('band:' + band, artist);
     roles.forEach(function(role) {
       redis_client.sadd('artist:' + band + ':' + artist, role);

--- a/chap8-redis/pre_populate.js
+++ b/chap8-redis/pre_populate.js
@@ -46,7 +46,7 @@ function trackLineCount() {
  */
 function populateRedis() {
   csv().
-  fromPath( tsvFileName, { delimiter: '\t', quote: '' }).
+  from.path( tsvFileName, { delimiter: '\t', quote: '' }).
   on('data', function(data, index) {
     var
       artist = data[2],


### PR DESCRIPTION
Having tried the polygot exercise in Chapter 8, there have been several deprecations in the Node http and csv libraries. This PR addresses these deprecations, and I've successfully used them to populate CouchDB.
