### PR TITLE
Fix relative links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ Here is the code for each chapter of the seven languages book with attempted bug
 
 The book to follow along is [Seven Databases in Seven Weeks](http://pragprog.com/book/rwdata/seven-databases-in-seven-weeks) available [here](http://pragprog.com/book/rwdata/seven-databases-in-seven-weeks).
 
-* [PostgreSQL](swmcc/databases/tree/master/chap2-postgresql)
-* https://github.com/sevenweeks/databases/tree/master/chap2-postgresql
+* [PostgreSQL](https://github.com/sevenweeks/databases/tree/master/chap2-postgresql)
 * [Riak](databases/tree/master/chap3-riak)
 * [HBase](databases/tree/master/chap4-hbase)
 * [MongoDB](databases/tree/master/chap5-mongo)

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Here is the code for each chapter of the seven languages book with attempted bug
 The book to follow along is [Seven Databases in Seven Weeks](http://pragprog.com/book/rwdata/seven-databases-in-seven-weeks) available [here](http://pragprog.com/book/rwdata/seven-databases-in-seven-weeks).
 
 * [PostgreSQL](https://github.com/sevenweeks/databases/tree/master/chap2-postgresql)
-* [Riak](databases/tree/master/chap3-riak)
-* [HBase](databases/tree/master/chap4-hbase)
-* [MongoDB](databases/tree/master/chap5-mongo)
-* [CouchDB](databases/tree/master/chap6-couch)
-* [Neo4j](databases/tree/master/chap7-neo4j)
-* [Redis](databases/tree/master/chap8-redis)
+* [Riak](https://github.com/sevenweeks/databases/tree/master/chap3-riak)
+* [HBase](https://github.com/sevenweeks/databases/tree/master/chap4-hbase)
+* [MongoDB](https://github.com/sevenweeks/databases/tree/master/chap5-mongo)
+* [CouchDB](https://github.com/sevenweeks/databases/tree/master/chap6-couch)
+* [Neo4j](https://github.com/sevenweeks/databases/tree/master/chap7-neo4j)
+* [Redis](https://github.com/sevenweeks/databases/tree/master/chap8-redis)
 
 The book code is also available from the [publisher's website](http://pragprog.com/titles/rwdata/source_code), though this github repo likely more up to date.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Here is the code for each chapter of the seven languages book with attempted bug
 
 The book to follow along is [Seven Databases in Seven Weeks](http://pragprog.com/book/rwdata/seven-databases-in-seven-weeks) available [here](http://pragprog.com/book/rwdata/seven-databases-in-seven-weeks).
 
-* [PostgreSQL](databases/tree/master/chap2-postgresql)
+* [PostgreSQL](swmcc/databases/tree/master/chap2-postgresql)
+* https://github.com/sevenweeks/databases/tree/master/chap2-postgresql
 * [Riak](databases/tree/master/chap3-riak)
 * [HBase](databases/tree/master/chap4-hbase)
 * [MongoDB](databases/tree/master/chap5-mongo)


### PR DESCRIPTION
According to https://github.com/github/markup/issues/84 - relative links wont really work in a README. So just updated each chapter link to back to https://github.com/sevenweeks/databases/xxxxxx 

Might be worth fixing.. So here it is if you want it.
